### PR TITLE
Convert readme to a table of the models and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # CodeProject.AI-Custom-IPcam-Models
 
-**IPcam-combined Labels:**
-    - person, bicycle, car, motorcycle, bus, truck, bird, cat, dog, horse, sheep, cow, bear, deer, rabbit, raccoon, fox, skunk, squirrel, pig
+| Model          | person | Vehicle | bicycle | car | motorcycle | cat | dog | bus | bird | truck | horse | sheep | cow | bear | deer | rabbit | raccoon | fox | skunk | squirrel | pig | DayPlate | NightPlate |
+| -------------- | ------ | ------- | ------- | --- | ---------- | --- | --- | --- | ---- | ----- | ----- | ----- | --- | ---- | ---- | ------ | ------- | --- | ----- | -------- | --- | -------- | ---------- |
+| **IPcam-combined** | **L**      | \-      | **L**       | **L**   | **L**          | **L**   | **L**   | **L**   | **L**    | **L**     | **L**     | **L**     | **L**   | **L**    | **L**    | **L**      | **L**       | **L**   | **L**     | **L**        | **L**   | \-       | \-         |
+| **IPcam-general**  | **L&D**    | **L&D**     | \-      | \-  | \-         | \-  | \-  | \-  | \-   | \-    | \-    | \-    | \-  | \-   | \-   | \-     | \-      | \-  | \-    | \-       | \-  | \-       | \-         |
+| **IPcam-animal**   | \-     | \-      | \-      | \-  | \-         | **L**   | **L**   | \-  | **L**    | \-    | **L**     | **L**     | **L**   | **L**    | **L**    | **L**      | **L**       | **L**   | **L**     | **L**        | **L**   | \-       | \-         |
+| **IPcam-dark**     | **D**      | \-      | **D**       | **D**   | **D**          | **D**   | **D**   | **D**   | \-   | \-    | \-    | \-    | \-  | \-   | \-   | \-     | \-      | \-  | \-    | \-       | \-  | \-       | \-         |
+| **license-plate**  | \-     | \-      | \-      | \-  | \-         | \-  | \-  | \-  | \-   | \-    | \-    | \-    | \-  | \-   | \-   | \-     | \-      | \-  | \-    | \-       | \-  | **L**        | **D**          |
 
-**IPcam-general Labels (includes dark models images):**
-    - person, vehicle
 
-**IPcam-animal Labels:**
-    - bird, cat, dog, horse, sheep, cow, bear, deer, rabbit, raccoon, fox, skunk, squirrel, pig
+### Legend
 
-**IPcam-dark Labels:**
-    - Bicycle, Bus, Car, Cat, Dog, Motorcycle, Person
-    
-**license-plate Labels:**
-    - DayPlate, NightPlate
+- **L**: Light
+- **D**: Dark

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodeProject.AI-Custom-IPcam-Models
 
-| Model          | person | Vehicle | bicycle | car | motorcycle | cat | dog | bus | bird | truck | horse | sheep | cow | bear | deer | rabbit | raccoon | fox | skunk | squirrel | pig | DayPlate | NightPlate |
+| Model          | person | vehicle | bicycle | car | motorcycle | cat | dog | bus | bird | truck | horse | sheep | cow | bear | deer | rabbit | raccoon | fox | skunk | squirrel | pig | DayPlate | NightPlate |
 | -------------- | ------ | ------- | ------- | --- | ---------- | --- | --- | --- | ---- | ----- | ----- | ----- | --- | ---- | ---- | ------ | ------- | --- | ----- | -------- | --- | -------- | ---------- |
 | **IPcam-combined** | **L**      | \-      | **L**       | **L**   | **L**          | **L**   | **L**   | **L**   | **L**    | **L**     | **L**     | **L**     | **L**   | **L**    | **L**    | **L**      | **L**       | **L**   | **L**     | **L**        | **L**   | \-       | \-         |
 | **IPcam-general**  | **L&D**    | **L&D**     | \-      | \-  | \-         | \-  | \-  | \-  | \-   | \-    | \-    | \-    | \-  | \-   | \-   | \-     | \-      | \-  | \-    | \-       | \-  | \-       | \-         |


### PR DESCRIPTION
@MikeLud I'm struggling to understand whether the combined model contains just light labels, or both light and dark, or whether animals has any dark models included.
So instead of annoying you in an issue, perhaps moving the readme to a table view would be nice for everyone to understand at a glance?

I've started here with my understanding of the labels, perhaps you could review/fix any issues you see?

I'm also not sure if the capitalisation differences on the IPcam-dark and license-plate Labels are intentional or not? Should everything be lowercase? (Or is it set up this way to allow people to trigger differently for dark labels?)

_Easier to review [in preview mode](https://github.com/MikeLud/CodeProject.AI-Custom-IPcam-Models/pull/3/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) if that's not obvious._
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/2920947/233578768-ae58fc2e-5c13-4e0c-bf48-e41fbb0e1b70.png">
